### PR TITLE
[kernel-cmdline] Avoid build failure on newer GCCs. JB#62204

### DIFF
--- a/rpm/0001-mkbootimg-Fix-variable-scope.patch
+++ b/rpm/0001-mkbootimg-Fix-variable-scope.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] mkbootimg: Fix variable scope
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/mkbootimg.c b/mkbootimg.c
-index f72a2650fbbfd975217ab62ef9775e42a65807e3..a19c083bb2bff8bb3b3bff9abd3a9fed8d0f21dc 100644
+index f72a2650..a19c083b 100644
 --- a/mkbootimg.c
 +++ b/mkbootimg.c
 @@ -28,6 +28,7 @@

--- a/rpm/0002-Turn-off-Werror-on-libmincrypt.patch
+++ b/rpm/0002-Turn-off-Werror-on-libmincrypt.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pekka Vuorela <pekka.vuorela@jolla.com>
+Date: Tue, 22 Oct 2024 12:47:43 +0300
+Subject: [PATCH] Turn off -Werror on libmincrypt
+
+Let's avoid build failures caused by external changes.
+Now latest GCCs are warning on RSA_verify() but that's not even used
+here.
+---
+ libmincrypt/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libmincrypt/Makefile b/libmincrypt/Makefile
+index 3ef33026..dc26a087 100755
+--- a/libmincrypt/Makefile
++++ b/libmincrypt/Makefile
+@@ -27,7 +27,7 @@ $(LIB):$(LIB_OBJS)
+ 	$(CP) $@ ..
+ 
+ %.o:%.c
+-	$(CROSS_COMPILE)$(CC) -o $@ $(CFLAGS) -c $< $(INC) -Werror
++	$(CROSS_COMPILE)$(CC) -o $@ $(CFLAGS) -c $< $(INC)
+ 
+ clean:
+ 	$(RM) $(LIB_OBJS) $(LIB)

--- a/rpm/kernel-cmdline.spec
+++ b/rpm/kernel-cmdline.spec
@@ -6,7 +6,8 @@ License:    ASL 2.0
 URL:        https://github.com/mer-hybris/kernel-cmdline
 Source0:    %{name}-%{version}.tar.bz2
 Source1:    kernel-cmdline.sh
-Patch0:     0001-mkbootimg-Fix-variable-scope.patch
+Patch1:     0001-mkbootimg-Fix-variable-scope.patch
+Patch2:     0002-Turn-off-Werror-on-libmincrypt.patch
 
 %description
 Modify kernel command line with ease.
@@ -18,13 +19,11 @@ Modify kernel command line with ease.
 %make_build
 
 %install
-rm -rf %{buildroot}
 install -D -m 755 mkbootimg %{buildroot}%{_libexecdir}/%{name}/mkbootimg
 install -D -m 755 unpackbootimg %{buildroot}%{_libexecdir}/%{name}/unpackbootimg
 install -D -m 755 %{SOURCE1} %{buildroot}%{_bindir}/kernel-cmdline
 
 %files
-%defattr(-,root,root,-)
 %license NOTICE
 %dir %{_libexecdir}/kernel-cmdline
 %{_libexecdir}/%{name}/mkbootimg


### PR DESCRIPTION
Just turning off -Werror. The currently failing RSA_verify() is not even used for anything here.